### PR TITLE
Remove googleAnalyticsId

### DIFF
--- a/content/config.json
+++ b/content/config.json
@@ -3,7 +3,7 @@
   "url": "https://blog.iakoug.cn",
   "subtitle": "There are two colors in my head.",
   "copyright": "© 2017-2024 All rights reserved.",
-  "googleAnalyticsId": "G-7DNZ80VV7M",
+  "googleAnalyticsId": "",
   "postsLimit": 4,
   "pathPrefix": "/",
   "menu": [


### PR DESCRIPTION
It seems this repository is copied from https://github.com/amoseui/blog. 
Since googleAnalyticsId still remains in config.json, https://blog.iakoug.cn/ is being tracked in my Google Analytics report.